### PR TITLE
Add tooltip placement for filter

### DIFF
--- a/src/app/filters/filter-config.ts
+++ b/src/app/filters/filter-config.ts
@@ -16,4 +16,5 @@ export class FilterConfig {
   resultsCount: number;
   selectedCount: number;
   totalCount: number;
+  tooltipPlacement?: string;
 }

--- a/src/app/filters/filter-fields.component.html
+++ b/src/app/filters/filter-fields.component.html
@@ -1,11 +1,12 @@
 <div class="filter-pf filter-fields">
   <div class="input-group form-group">
     <div class="input-group-btn" dropdown>
-      <button type="button" class="btn btn-default filter-fields" dropdownToggle tooltip="Filter by" placement="top">
+      <button type="button" class="btn btn-default filter-fields" dropdownToggle
+              tooltip="Filter by" tooltipPlacement="{{config.tooltipPlacement}}">
         {{currentField.title}}
         <span class="caret"></span>
       </button>
-      <ul class="dropdown-menu" role="menu" dropdownMenu>
+      <ul role="menu" dropdownMenu>
         <li *ngFor="let field of config.fields">
           <a class="filter-field" role="menuitem" tabindex="-1" (click)="selectField(field)">
             {{field.title}}
@@ -20,7 +21,7 @@
     </div>
     <div *ngIf="currentField.type === 'select'">
       <div class="btn-group bootstrap-select form-control filter-select" dropdown >
-        <button type="button" class="btn btn-default dropdown-toggle" dropdownToggle>
+        <button type="button" class="btn btn-default" dropdownToggle>
           <span class="filter-option pull-left">{{currentValue || currentField.placeholder}}</span>
           <span class="caret"></span>
         </button>

--- a/src/app/filters/filter-fields.component.ts
+++ b/src/app/filters/filter-fields.component.ts
@@ -55,6 +55,9 @@ export class FilterFieldsComponent implements OnInit {
     if (this.config && this.config.fields === undefined) {
       this.config.fields = [];
     }
+    if (this.config && this.config.tooltipPlacement === undefined) {
+      this.config.tooltipPlacement = "top";
+    }
 
     let fieldFound: boolean = false;
     if (this.currentField !== undefined) {

--- a/src/app/filters/filter-results.component.html
+++ b/src/app/filters/filter-results.component.html
@@ -1,7 +1,7 @@
 <div class="filter-pf" *ngIf="config && config.appliedFilters && config.appliedFilters.length > 0">
   <div class="row toolbar-pf-results">
     <div class="col-sm-12">
-      <h5 *ngIf="config.resultsCount >= -1">{{config.resultsCount}} Results</h5>
+      <h5 *ngIf="config.resultsCount >= 0">{{config.resultsCount}} Results</h5>
       <p *ngIf="config.appliedFilters.length > 0">Active filters:</p>
       <ul class="list-inline">
         <li *ngFor="let filter of config.appliedFilters">

--- a/src/app/toolbar/examples/toolbar-example.component.ts
+++ b/src/app/toolbar/examples/toolbar-example.component.ts
@@ -144,8 +144,9 @@ export class ToolbarExampleComponent implements OnInit {
           value: 'December'
         }]
       }] as FilterField[],
+      appliedFilters: [],
       resultsCount: this.items.length,
-      //appliedFilters: []
+      tooltipPlacement: "right"
     } as FilterConfig;
 
     this.sortConfig = {


### PR DESCRIPTION
The filter's tooltip is cut off by planner's black header. This mod provides the ability to change the tooltip placement. Instead of being cut off on top, we can move the tool tip to the side.