### PR TITLE
Moved Patternfly styles from planner to tree list

### DIFF
--- a/src/app/treelist/treelist-item.component.html
+++ b/src/app/treelist/treelist-item.component.html
@@ -1,6 +1,6 @@
-<div class="tree-list-item"
-     (click)="select($event)"
-     [class.tree-list-item-selected]="isSelected()">
- <TreeNodeExpander [node]="node"></TreeNodeExpander>
- <template [ngTemplateOutlet]="template" [ngOutletContext]="{ node: node, index: index }"></template>
+<div class="list-group-item" [class.selected]="isSelected()" (click)="select($event)">
+  <div class="tree-list-item">
+    <TreeNodeExpander [node]="node"></TreeNodeExpander>
+    <template [ngTemplateOutlet]="template" [ngOutletContext]="{ node: node, index: index }"></template>
+  </div>
 </div>

--- a/src/app/treelist/treelist-item.component.scss
+++ b/src/app/treelist/treelist-item.component.scss
@@ -1,23 +1,21 @@
 @import "../../assets/stylesheets/_base";
 
-.tree-list-item {
-  align-items: center;
+.list-group-item {
+  border: none;
   cursor: pointer;
-  font-size: rem(12);
-  padding-bottom: 2px;
-  padding-left: 10px;
-  padding-right: 10px;
-  padding-top: 2px;
-}
-
-.tree-list-item-selected {
-  background-color: $color-pf-blue-100;
+  padding-left: 0;
   &:hover {
+    background-color: $color-pf-black-200;
+  }
+  &.selected {
     background-color: $color-pf-blue-100;
+    &:hover {
+      background-color: $color-pf-blue-100;
+    }
   }
 }
 
-// Toggle indentation -- row highlighting should occupy entire width
+// Indentation -- highlighting should occupy entire row
 .tree-children {
   padding-left: 0;
   .tree-list-item {
@@ -35,7 +33,25 @@
         .tree-list-item {
           padding-left: 80px;
         }
+        .tree-children {
+          .tree-list-item {
+            padding-left: 100px;
+          }
+        }
       }
     }
+  }
+}
+
+.tree-list-item {
+  padding-left: 10px;
+  .toggle-children-placeholder {
+    width: 15px;
+  }
+  .toggle-children-wrapper {
+    padding-right: 10px;
+  }
+  .toggle-children-wrapper-expanded {
+    padding-right: 7px;
   }
 }

--- a/src/app/treelist/treelist.component.html
+++ b/src/app/treelist/treelist.component.html
@@ -1,47 +1,49 @@
-<Tree #tree class="tree-list"
-      [nodes]="nodes"
-      [focused]="true"
-      [options]="options">
-  <template #treeNodeTemplate let-node let-index="index">
-    <template [ngTemplateOutlet]="listTemplate" [ngOutletContext]="{ node: node, index: index }"></template>
-  </template>
-  <template #loadingTemplate let-node let-index="index">
-    <template [ngTemplateOutlet]="loadTemplate" [ngOutletContext]="{ node: node, index: index }"></template>
-  </template>
-  <template #treeNodeFullTemplate
-            let-node="node"
-            let-index="index"
-            let-templates="templates">
-    <div
-      *ngIf="!node.isHidden"
-      class="tree-node tree-node-level-{{ node.level }}"
-      [class]="node.getClass()"
-      [class.tree-node-expanded]="node.isExpanded && node.hasChildren"
-      [class.tree-node-collapsed]="node.isCollapsed && node.hasChildren"
-      [class.tree-node-leaf]="node.isLeaf"
-      [class.tree-node-active]="node.isActive"
-      [class.tree-node-focused]="node.isFocused">
+<div class="list-group list-view-pf">
+  <Tree #tree class="tree-list"
+        [nodes]="nodes"
+        [focused]="true"
+        [options]="options">
+    <template #treeNodeTemplate let-node let-index="index">
+      <template [ngTemplateOutlet]="listTemplate" [ngOutletContext]="{ node: node, index: index }"></template>
+    </template>
+    <template #loadingTemplate let-node let-index="index">
+      <template [ngTemplateOutlet]="loadTemplate" [ngOutletContext]="{ node: node, index: index }"></template>
+    </template>
+    <template #treeNodeFullTemplate
+              let-node="node"
+              let-index="index"
+              let-templates="templates">
+      <div
+          *ngIf="!node.isHidden"
+          class="tree-node tree-node-level-{{ node.level }}"
+          [class]="node.getClass()"
+          [class.tree-node-expanded]="node.isExpanded && node.hasChildren"
+          [class.tree-node-collapsed]="node.isCollapsed && node.hasChildren"
+          [class.tree-node-leaf]="node.isLeaf"
+          [class.tree-node-active]="node.isActive"
+          [class.tree-node-focused]="node.isFocused">
 
-      <TreeNodeDropSlot *ngIf="index === 0" [dropIndex]="index" [node]="node.parent"></TreeNodeDropSlot>
+        <TreeNodeDropSlot *ngIf="index === 0" [dropIndex]="index" [node]="node.parent"></TreeNodeDropSlot>
 
-      <div class="node-wrapper" [style.padding-left]="node.getNodePadding()">
-        <TreeNodeExpander [node]="node" *ngIf="showExpander"></TreeNodeExpander>
-        <div class="node-content-wrapper"
-             (click)="node.mouseAction('click', $event)"
-             (dblclick)="node.mouseAction('dblClick', $event)"
-             (contextmenu)="node.mouseAction('contextMenu', $event)"
-             (treeDrop)="node.onDrop($event)"
-             [treeAllowDrop]="node.allowDrop.bind(node)"
-             [treeDrag]="node"
-             [treeDragEnabled]="node.allowDrag()">
+        <div class="node-wrapper" [style.padding-left]="node.getNodePadding()">
+          <TreeNodeExpander [node]="node" *ngIf="showExpander"></TreeNodeExpander>
+          <div class="node-content-wrapper"
+               (click)="node.mouseAction('click', $event)"
+               (dblclick)="node.mouseAction('dblClick', $event)"
+               (contextmenu)="node.mouseAction('contextMenu', $event)"
+               (treeDrop)="node.onDrop($event)"
+               [treeAllowDrop]="node.allowDrop.bind(node)"
+               [treeDrag]="node"
+               [treeDragEnabled]="node.allowDrag()">
 
-          <TreeNodeContent [node]="node" [index]="index" [template]="templates.treeNodeTemplate">
-          </TreeNodeContent>
+            <TreeNodeContent [node]="node" [index]="index" [template]="templates.treeNodeTemplate">
+            </TreeNodeContent>
+          </div>
         </div>
-      </div>
 
-      <TreeNodeChildren [node]="node" [templates]="templates"></TreeNodeChildren>
-      <TreeNodeDropSlot [dropIndex]="index + 1" [node]="node.parent"></TreeNodeDropSlot>
-    </div>
-  </template>
-</Tree>
+        <TreeNodeChildren [node]="node" [templates]="templates"></TreeNodeChildren>
+        <TreeNodeDropSlot [dropIndex]="index + 1" [node]="node.parent"></TreeNodeDropSlot>
+      </div>
+    </template>
+  </Tree>
+</div>


### PR DESCRIPTION
I moved a couple Patternfly styles (list-view-pf, list-group & list-group-item) from the planner UI to the tree list component.

We will want to use these Patternfly styles in other places with the tree list. This means there are far less tree list styles to override in planner and/or elsewhere.

Note this is one of two PRs. After this is merged, I'll create another PR for planner with the latest npm version number.