### PR TITLE
Deprecation fix

### DIFF
--- a/src/app/filters/filter-fields.component.html
+++ b/src/app/filters/filter-fields.component.html
@@ -2,7 +2,7 @@
   <div class="input-group form-group">
     <div class="input-group-btn" dropdown>
       <button type="button" class="btn btn-default filter-fields" dropdownToggle
-              tooltip="Filter by" tooltipPlacement="{{config.tooltipPlacement}}">
+              tooltip="Filter by" placement="{{config.tooltipPlacement}}">
         {{currentField.title}}
         <span class="caret"></span>
       </button>


### PR DESCRIPTION
Due to recent Karma changes, the unit tests are now outputting the following warning for the filter fields component.

WARN: 'tooltipPlacement was deprecated, please use `placement` instead'

I renamed the attribute; however, this means that Planner must upgrade ng2-bootstrap to 1.3.3 -- I believe they are still on 1.1.16. I will create another PR for that.