### PR TITLE
Provide a way to obtain the underlying objects

### DIFF
--- a/src/app/treelist/treelist-item.component.ts
+++ b/src/app/treelist/treelist-item.component.ts
@@ -33,6 +33,15 @@ export class TreeListItemComponent implements OnInit {
   ngOnInit(): void {
   }
 
+  /**
+   * Return tree node. Useful to obtain the underlying objects (i.e., node.data) provided to tree list
+   *
+   * @returns {TreeNode}
+   */
+  getNode(): TreeNode {
+    return this.node;
+  }
+
   select(event: MouseEvent): void {
     event.stopPropagation();
     this.onSelect.emit(this);


### PR DESCRIPTION
When a row is selected, I want to obtain the underlying objects provided to tree list via the onSelect event. This would be useful in planner to get the WorkItem object associated with the row.