### PR TITLE
Changed name of selector to avoid inherited styling

### DIFF
--- a/src/app/treelist/treelist-item.component.html
+++ b/src/app/treelist/treelist-item.component.html
@@ -1,4 +1,4 @@
-<div class="list-group-item" [class.selected]="isSelected()" (click)="select($event)">
+<div class="list-group-item" [class.tree-item-selected]="isSelected()" (click)="select($event)">
   <div class="tree-list-item">
     <TreeNodeExpander [node]="node"></TreeNodeExpander>
     <template [ngTemplateOutlet]="template" [ngOutletContext]="{ node: node, index: index }"></template>

--- a/src/app/treelist/treelist-item.component.scss
+++ b/src/app/treelist/treelist-item.component.scss
@@ -7,7 +7,7 @@
   &:hover {
     background-color: $color-pf-black-200;
   }
-  &.selected {
+  &.tree-item-selected {
     background-color: $color-pf-blue-100;
     &:hover {
       background-color: $color-pf-blue-100;


### PR DESCRIPTION
The tree list is not displaying a selected row highlighting properly in planner. When the user hovers over a row, it should still appear selected. 

Somewhere in planner or PF, the "selected" selector is being overridden. Don't want to add a bunch of extra CSS to override this selector name in planner -- it already exists in treelist.