### PR TITLE
Expose underlying angular2-tree-component events

### DIFF
--- a/src/app/treelist/examples/treelist-example.component.html
+++ b/src/app/treelist/examples/treelist-example.component.html
@@ -12,7 +12,9 @@
             [loadTemplate]="treeListLoadTemplate"
             [nodes]="nodes"
             [options]="options"
-            [showExpander]="false">
+            [showExpander]="false"
+            (onMoveNode)="handleMoveNode($event)"
+            (onToggle)="handleToggle($event)">
           <template #treeListLoadTemplate let-node="node" let-index="index">
             <span>Loading...</span>
           </template>
@@ -29,6 +31,16 @@
           </template>
         </alm-tree-list>
       </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <label class="actions-label">Actions: </label>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <textarea rows="3" class="col-md-12">{{actionsText}}</textarea>
     </div>
   </div>
 </div>

--- a/src/app/treelist/examples/treelist-example.component.ts
+++ b/src/app/treelist/examples/treelist-example.component.ts
@@ -43,6 +43,7 @@ export class TreeListExampleComponent implements OnInit {
   @ViewChild('treeListTemplate') treeListTemplate: TemplateRef<any>;
   @ViewChild('treeList') treeList: TreeListComponent;
 
+  actionsText: string = "";
   nodes: any[];
   selectedTreeListItem: TreeListItemComponent;
 
@@ -131,5 +132,22 @@ export class TreeListExampleComponent implements OnInit {
     }
     treeListItem.setSelected(true);
     this.selectedTreeListItem = treeListItem;
+  }
+
+  // Events
+
+  handleMoveNode($event: any): void {
+   this.actionsText = "Event name: " + $event.eventName +
+     ", node: " + $event.node.name +
+     ", to index: " + $event.to.index + "\n" + this.actionsText;
+  }
+
+  handleToggle($event: any): void {
+    this.actionsText = "Event name: " + $event.eventName +
+      ", isExpanded: " + $event.isExpanded + "\n" + this.actionsText;
+  }
+
+  handleToggleExpanded($event: any): void {
+    this.actionsText = "Event name: " + $event.eventName + "\n" + this.actionsText;
   }
 }

--- a/src/app/treelist/treelist.component.html
+++ b/src/app/treelist/treelist.component.html
@@ -2,7 +2,12 @@
   <Tree #tree class="tree-list"
         [nodes]="nodes"
         [focused]="true"
-        [options]="options">
+        [options]="options"
+        (onEvent)="handleEvent($event)"
+        (onInitialized)="handleInitialized($event)"
+        (onMoveNode)="handleMoveNode($event)"
+        (onToggle)="handleToggle($event)"
+        (onUpdateData)="handleUpdateData($event)">
     <template #treeNodeTemplate let-node let-index="index">
       <template [ngTemplateOutlet]="listTemplate" [ngOutletContext]="{ node: node, index: index }"></template>
     </template>

--- a/src/app/treelist/treelist.component.ts
+++ b/src/app/treelist/treelist.component.ts
@@ -1,7 +1,9 @@
 import {
   Component,
+  EventEmitter,
   Input,
   OnInit,
+  Output,
   TemplateRef,
   ViewChild,
   ViewEncapsulation
@@ -12,6 +14,15 @@ import {
 } from 'angular2-tree-component';
 
 // See docs: https://angular2-tree.readme.io/docs
+//
+// Supported events:
+//
+// onEvent - Catch-all event that is triggered on every other event that is triggered
+// onInitialized - Triggers after tree model was created
+// onMoveNode - This event is fired when drag and dropping a node
+// onToggle - Triggers when tree node is expanded or collapsed
+// onUpdateData - Triggers after tree model was updated
+//
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'alm-tree-list',
@@ -26,12 +37,40 @@ export class TreeListComponent implements OnInit {
   @Input() options: any;
   @Input() showExpander: boolean = true;
 
+  @Output('onEvent') onEvent = new EventEmitter();
+  @Output('onInitialized') onInitialized = new EventEmitter();
+  @Output('onMoveNode') onMoveNode = new EventEmitter();
+  @Output('onToggle') onToggle = new EventEmitter();
+  @Output('onUpdateData') onUpdateData = new EventEmitter();
+
   @ViewChild(TreeComponent) tree: TreeComponent;
 
   constructor() {
   }
 
   ngOnInit(): void {
+  }
+
+  // Events
+
+  handleEvent($event: any): void {
+    this.onEvent.emit($event);
+  }
+
+  handleInitialized($event: any): void {
+    this.onInitialized.emit($event);
+  }
+
+  handleMoveNode($event: any): void {
+    this.onMoveNode.emit($event);
+  }
+
+  handleToggle($event: any): void {
+    this.onToggle.emit($event);
+  }
+
+  handleUpdateData($event: any): void {
+    this.onUpdateData.emit($event);
   }
 
   // Helper function to update tree when moving items


### PR DESCRIPTION
This is for issue #48.

Supported events:

onEvent - Catch-all event that is triggered on every other event that is triggered
onInitialized - Triggers after tree model was created
onMoveNode - This event is fired when drag and dropping a node
onToggle - Triggers when tree node is expanded or collapsed
onUpdateData - Triggers after tree model was updated