### PR TITLE
fix: Clean up inconsistent variable names

### DIFF
--- a/src/app/config/action.ts
+++ b/src/app/config/action.ts
@@ -1,16 +1,20 @@
 /*
  * An action for a button, dropdown, etc:
  *
+ * disabled - Set to true to disable the action
  * id - Optional unique Id for the filter field, useful for comparisons
- * isDisabled - set to true to disable the action
- * isSeparator - set to true if this is a placehodler for a separator rather than an action
  * name - The name of the action, displayed on the button
+ * separator - Set to true if this is a placehodler for a separator rather than an action
+ * template - Optional template name for including custom content (listView only)
  * title - Optional title, used for the tooltip
+ * visible - Set to false if this menu option should be hidden
  */
 export class Action {
+  disabled?: boolean = false;
   id?: string;
-  isDisabled?: boolean = false;
-  isSeparator?: boolean = false;
   name: string;
+  separator?: boolean = false;
+  template?: string;
   title?: string;
+  visible?: boolean;
 }

--- a/src/app/config/view.ts
+++ b/src/app/config/view.ts
@@ -1,14 +1,14 @@
 /*
  * A view available for selection containing:
  *
+ * disabled - True if view is disabled
  * iconClass - Icon class to use for the view selector
  * id - Unique id for the view, used for comparisons
- * isDisabled - True if view is disabled
  * title - Optional title, uses as a tooltip for the view selector
  */
 export class View {
+  disabled?: boolean = false;
   iconClass: string;
   id: string;
-  isDisabled?: boolean = false;
   title: string;
 }

--- a/src/app/filters/filter-fields.component.html
+++ b/src/app/filters/filter-fields.component.html
@@ -20,7 +20,7 @@
              (keypress)="onValueKeyPress($event)"/>
     </div>
     <div *ngIf="currentField.type === 'select'">
-      <div class="btn-group bootstrap-select form-control filter-select" dropdown >
+      <div class="btn-group bootstrap-select form-control filter-select" dropdown>
         <button type="button" class="btn btn-default" dropdownToggle>
           <span class="filter-option pull-left">{{currentValue || currentField.placeholder}}</span>
           <span class="caret"></span>

--- a/src/app/notification/examples/toast-notification-example.component.ts
+++ b/src/app/notification/examples/toast-notification-example.component.ts
@@ -51,8 +51,8 @@ export class ToastNotificationExampleComponent implements OnInit {
       name: 'Another Action',
       title: 'Do something else'
     },{
+      disabled: true,
       id: 'moreActions3',
-      isDisabled: true,
       name: 'Disabled Action',
       title: 'Unavailable action'
     },{
@@ -61,7 +61,7 @@ export class ToastNotificationExampleComponent implements OnInit {
       title: ''
     },{
       id: 'moreActions5',
-      isSeparator: true
+      separator: true
     },{
       id: 'moreActions6',
       name: 'Grouped Action 1',

--- a/src/app/notification/examples/toast-notification-list-example.component.ts
+++ b/src/app/notification/examples/toast-notification-list-example.component.ts
@@ -62,8 +62,8 @@ export class ToastNotificationListExampleComponent implements OnInit {
       name: 'Another Action',
       title: 'Do something else'
     },{
+      disabled: true,
       id: 'moreActions3',
-      isDisabled: true,
       name: 'Disabled Action',
       title: 'Unavailable action'
     },{
@@ -72,7 +72,7 @@ export class ToastNotificationListExampleComponent implements OnInit {
       title: ''
     },{
       id: 'moreActions5',
-      isSeparator: true
+      separator: true
     },{
       id: 'moreActions6',
       name: 'Grouped Action 1',

--- a/src/app/notification/toast-notification.component.html
+++ b/src/app/notification/toast-notification.component.html
@@ -7,9 +7,9 @@
     </button>
     <ul dropdownMenu class="dropdown-menu-right" aria-labelledby="dropdownKebabRight">
       <li *ngFor="let action of moreActions"
-          [attr.role]="action.isSeparator === true ? 'separator' : 'menuitem'"
-          [ngClass]="{'divider': action.isSeparator === true, 'disabled': action.isDisabled === true}">
-        <a ng-if="action.isSeparator !== true"
+          [attr.role]="action.separator === true ? 'separator' : 'menuitem'"
+          [ngClass]="{'divider': action.separator === true, 'disabled': action.disabled === true}">
+        <a ng-if="action.separator !== true"
            class="secondary-action"
            title="{{action.title}}"
            (click)="handleAction(action)">

--- a/src/app/notification/toast-notification.component.ts
+++ b/src/app/notification/toast-notification.component.ts
@@ -49,7 +49,7 @@ export class ToastNotificationComponent implements OnInit {
   // Action functions
 
   handleAction(action: Action): void {
-    if (action && action.isDisabled !== true) {
+    if (action && action.disabled !== true) {
       this.onActionSelect.emit({
         action: action,
         notification: this.notification

--- a/src/app/toolbar/examples/toolbar-example.component.html
+++ b/src/app/toolbar/examples/toolbar-example.component.html
@@ -44,7 +44,7 @@
   </div>
   <div class="row">
     <div class="col-md-12" *ngIf="view.id == 'listView'">
-      <div *ngFor="let item of items" class="col-md-12 cfme-row-column">
+      <div *ngFor="let item of items" class="col-md-12">
         <div class="row">
           <div class="col-md-3">
             <span>{{item.name}}</span>

--- a/src/app/toolbar/examples/toolbar-example.component.ts
+++ b/src/app/toolbar/examples/toolbar-example.component.ts
@@ -200,10 +200,10 @@ export class ToolbarExampleComponent implements OnInit {
           title: 'Do something else'
         },
         {
+          disabled: true,
           id: 'moreActions3',
           name: 'Disabled Action',
           title: 'Unavailable action',
-          isDisabled: true
         },
         {
           id: 'moreActions4',
@@ -213,7 +213,7 @@ export class ToolbarExampleComponent implements OnInit {
         {
           id: 'moreActions5',
           name: '',
-          isSeparator: true
+          separator: true
         },
         {
           id: 'moreActions6',

--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -15,7 +15,7 @@
                   *ngFor="let action of config.actionsConfig.primaryActions"
                   title="{{action.title}}"
                   (click)="handleAction(action)"
-                  [disabled]="action.isDisabled === true">
+                  [disabled]="action.disabled === true">
             {{action.name}}
           </button>
         </span>
@@ -29,9 +29,9 @@
           </button>
           <ul dropdownMenu aria-labelledby="dropdownKebab">
             <li *ngFor="let action of config.actionsConfig.moreActions"
-                [attr.role]="action.isSeparator === true ? 'separator' : 'menuitem'"
-                [ngClass]="{'divider': action.isSeparator === true, 'disabled': action.isDisabled === true}">
-              <a *ngIf="action.isSeparator !== true"
+                [attr.role]="action.separator === true ? 'separator' : 'menuitem'"
+                [ngClass]="{'divider': action.separator === true, 'disabled': action.disabled === true}">
+              <a *ngIf="action.separator !== true"
                  class="secondary-action"
                  title="{{action.title}}"
                  (click)="handleAction(action)">
@@ -47,7 +47,7 @@
           <template [ngTemplateOutlet]="viewsTemplate" [ngOutletContext]="{}"></template>
           <span *ngIf="config.viewsConfig">
             <button *ngFor="let view of config.viewsConfig.views" class="btn btn-link"
-                    [ngClass]="{'active': isViewSelected(view), 'disabled': view.isDisabled === true}"
+                    [ngClass]="{'active': isViewSelected(view), 'disabled': view.disabled === true}"
                     title={{view.title}}  (click)="viewSelected(view)">
               <i class="{{view.iconClass}}"></i>
             </button>

--- a/src/app/toolbar/toolbar.component.spec.ts
+++ b/src/app/toolbar/toolbar.component.spec.ts
@@ -62,10 +62,10 @@ describe('Toolbar component - ', () => {
             title: 'Do something else'
           },
           {
+            disabled: true,
             id: 'moreActions3',
             name: 'Disabled Action',
             title: 'Unavailable action',
-            isDisabled: true
           },
           {
             id: 'moreActions4',
@@ -75,7 +75,7 @@ describe('Toolbar component - ', () => {
           {
             id: 'moreActions5',
             name: '',
-            isSeparator: true
+            separator: true
           },
           {
             id: 'moreActions6',
@@ -564,7 +564,7 @@ describe('Toolbar component - ', () => {
     fixture.detectChanges();
     expect(action).toBe(config.actionsConfig.primaryActions[1]);
 
-    config.actionsConfig.primaryActions[1].isDisabled = true;
+    config.actionsConfig.primaryActions[1].disabled = true;
     fixture.detectChanges();
     action = null;
 

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -79,7 +79,7 @@ export class ToolbarComponent implements OnInit {
   // Action functions
 
   handleAction(action: Action): void {
-    if (action && action.isDisabled !== true) {
+    if (action && action.disabled !== true) {
       this.onActionSelect.emit(action);
     }
   }
@@ -141,7 +141,7 @@ export class ToolbarComponent implements OnInit {
 
   viewSelected (view: View): void {
     this.config.viewsConfig.currentView = view;
-    if (!view.isDisabled) {
+    if (!view.disabled) {
       this.onViewSelect.emit(view);
     }
   }

--- a/src/app/treelist/examples/treelist-example.component.ts
+++ b/src/app/treelist/examples/treelist-example.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  ContentChild,
   OnInit,
   TemplateRef,
   ViewChild,
@@ -38,9 +39,9 @@ const actionMapping: IActionMapping = {
   templateUrl: './treelist-example.component.html'
 })
 export class TreeListExampleComponent implements OnInit {
-  @ViewChild('treeListItemTemplate') treeListItemTemplate: TemplateRef<any>;
-  @ViewChild('treeListLoadTemplate') treeListLoadTemplate: TemplateRef<any>;
-  @ViewChild('treeListTemplate') treeListTemplate: TemplateRef<any>;
+  @ContentChild('treeListItemTemplate') treeListItemTemplate: TemplateRef<any>;
+  @ContentChild('treeListLoadTemplate') treeListLoadTemplate: TemplateRef<any>;
+  @ContentChild('treeListTemplate') treeListTemplate: TemplateRef<any>;
   @ViewChild('treeList') treeList: TreeListComponent;
 
   actionsText: string = "";


### PR DESCRIPTION
Want to clean up a couple things like inconsistent variable names inherited from various Angular Patternfly components. The new list view follows these naming conventions.