### PR TITLE
fix(filter-fields): remove overwritten font size from filter fields css

### DIFF
--- a/src/app/filters/filter-fields.component.scss
+++ b/src/app/filters/filter-fields.component.scss
@@ -25,7 +25,7 @@
     background-color: #fff; //@color-pf-white;
     background-image: none;
     color: #8b8d8f; //@color-pf-black-500;
-    font-size: 12px;
+    //font-size: 12px;
     font-style: italic;
     font-weight: 400;
   }


### PR DESCRIPTION
remove overwritten font size from filter fields css so that base font size would work