### PR TITLE
fix(list view): Headers must be on own row

### DIFF
--- a/src/app/listview/examples/listview-example.component.html
+++ b/src/app/listview/examples/listview-example.component.html
@@ -22,46 +22,74 @@
           (onSelect)="handleSelect($event)"
           (onSelectionChange)="handleSelectionChange($event)">
         <ng-template #itemTemplate let-item="item" let-index="index">
-          <div class="list-view-pf-left">
-            <span class="fa fa-plane list-view-pf-icon-sm"></span>
-          </div>
-          <div class="list-view-pf-body">
-            <div class="list-view-pf-description">
-              <div class="list-group-item-heading">
-                <span class="list-group-heading" *ngIf="index === 0">NAME</span>
-                {{item.name}}
+          <div *ngIf="index === 0; then showHeader else showCol"></div>
+          <ng-template #showHeader>
+            <div class="list-view-pf-left">
+              <!-- Extra padding for icon -->
+              <span class="margin-right-30"></span>
+            </div>
+            <div class="list-view-pf-body">
+              <div class="list-view-pf-description">
+                <div class="list-group-item-heading">
+                  <span class="list-group-heading">{{item.name}}</span>
+                </div>
+                <div class="list-group-item-text">
+                  <span class="list-group-heading">{{item.address}}</span>
+                </div>
               </div>
-              <div class="list-group-item-text">
-                <span class="list-group-heading" *ngIf="index === 0">ADDRESS</span>
-                {{item.address}}
+              <div class="list-view-pf-additional-info">
+                <div class="list-view-pf-additional-info-item">
+                  <span class="list-group-heading">{{item.additionalInfo}}
+                    <i class="pficon pficon-info" tooltip="Additional info"></i>
+                  </span>
+                </div>
               </div>
             </div>
-            <div class="list-view-pf-additional-info">
-              <div class="list-view-pf-additional-info-item">
-                <span class="list-group-heading" *ngIf="index === 0">ADDITOINAL INFO</span>
-                <span class="pficon pficon-screen"></span>
-                <strong>8</strong> Hosts
+          </ng-template>
+          <ng-template #showCol>
+            <div class="list-view-pf-left">
+              <span class="fa fa-plane list-view-pf-icon-sm"></span>
+            </div>
+            <div class="list-view-pf-body">
+              <div class="list-view-pf-description">
+                <div class="list-group-item-heading">
+                  {{item.name}}
+                </div>
+                <div class="list-group-item-text">
+                  {{item.address}}
+                </div>
               </div>
-              <div class="list-view-pf-additional-info-item">
-                <span class="pficon pficon-cluster"></span>
-                <strong>6</strong> Clusters
-              </div>
-              <div class="list-view-pf-additional-info-item">
-                <span class="pficon pficon-container-node"></span>
-                <strong>10</strong> Nodes
-              </div>
-              <div class="list-view-pf-additional-info-item">
-                <span class="pficon pficon-image"></span>
-                <strong>8</strong> Images
+              <div class="list-view-pf-additional-info">
+                <div class="list-view-pf-additional-info-item">
+                  <span class="pficon pficon-screen"></span>
+                  <strong>8</strong> Hosts
+                </div>
+                <div class="list-view-pf-additional-info-item">
+                  <span class="pficon pficon-cluster"></span>
+                  <strong>6</strong> Clusters
+                </div>
+                <div class="list-view-pf-additional-info-item">
+                  <span class="pficon pficon-container-node"></span>
+                  <strong>10</strong> Nodes
+                </div>
+                <div class="list-view-pf-additional-info-item">
+                  <span class="pficon pficon-image"></span>
+                  <strong>8</strong> Images
+                </div>
               </div>
             </div>
-          </div>
+          </ng-template>
         </ng-template>
         <ng-template #actionTemplate let-item="item" let-index="index">
-          <span class="list-group-heading" *ngIf="index === 0">ACTIONS</span>
-          <button class="btn btn-default"
-                  (click)="handleInlineAction($event, 'Action button')">Action</button>
-          <span class="dropdown-kebab-pf dropdown" dropdown>
+          <div *ngIf="index === 0; then showHeader else showCol"></div>
+          <ng-template #showHeader>
+            <!-- Extra padding for button -->
+            <span class="list-group-heading margin-right-50">{{item.actions}}</span>
+          </ng-template>
+          <ng-template #showCol>
+            <button class="btn btn-default"
+                    (click)="handleInlineAction($event, 'Action button')">Action</button>
+            <span class="dropdown-kebab-pf dropdown" dropdown>
             <button class="btn btn-link dropdown-toggle" type="button" dropdownToggle>
               <span class="fa fa-ellipsis-v"></span>
             </button>
@@ -93,6 +121,7 @@
               </li>
             </ul>
           </span>
+          </ng-template>
         </ng-template>
         <ng-template #itemExpandedTemplate let-item="item" let-index="index">
           <div class="row">

--- a/src/app/listview/examples/listview-example.component.scss
+++ b/src/app/listview/examples/listview-example.component.scss
@@ -1,1 +1,9 @@
 @import '../../../assets/stylesheets/_base';
+
+.margin-right-30 {
+  margin-right: 30px;
+}
+
+.margin-right-50 {
+  margin-right: 50px;
+}

--- a/src/app/listview/examples/listview-example.component.ts
+++ b/src/app/listview/examples/listview-example.component.ts
@@ -47,6 +47,12 @@ export class ListViewExampleComponent implements OnInit {
 
   ngOnInit(): void {
     this.allItems = [{
+      // First array item can be empty for row header
+      name: "NAME",
+      actions: "ACTIONS",
+      additionalInfo: "ADDITOINAL INFO",
+      address: "ADDRESS"
+    },{
       name: "Fred Flintstone",
       address: "20 Dinosaur Way",
       city: "Bedrock",
@@ -177,6 +183,7 @@ export class ListViewExampleComponent implements OnInit {
       dblClick: false,
       dragEnabled: false,
       emptyStateConfig: this.emptyStateConfig,
+      headingRow: true,
       multiSelect: false,
       selectItems: false,
       selectionMatchProp: 'name',

--- a/src/app/listview/examples/listview-example.module.ts
+++ b/src/app/listview/examples/listview-example.module.ts
@@ -1,6 +1,6 @@
 import { NgModule }  from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { DropdownModule } from 'ng2-bootstrap';
+import { DropdownModule, TooltipModule } from 'ng2-bootstrap';
 import { FormsModule } from '@angular/forms';
 import { HttpModule, Http } from '@angular/http';
 
@@ -16,7 +16,8 @@ import { ListViewExampleRoutingModule } from './listview-example-routing.module'
     FormsModule,
     HttpModule,
     ListViewExampleRoutingModule,
-    ListViewModule
+    ListViewModule,
+    TooltipModule
   ]
 })
 export class ListViewExampleModule {

--- a/src/app/listview/listview-config.ts
+++ b/src/app/listview/listview-config.ts
@@ -8,6 +8,7 @@ export class ListViewConfig {
   dblClick?: boolean;
   dragEnabled?: boolean;
   emptyStateConfig?: EmptyStateConfig;
+  headingRow?: boolean;
   multiSelect?: boolean;
   selectedItems?: any[];
   selectItems?: boolean;

--- a/src/app/listview/listview.component.html
+++ b/src/app/listview/listview.component.html
@@ -1,40 +1,53 @@
 <span>
-  <div class="list-group list-view-pf list-view-pf-view"
-       dnd-list="items"
-       [ngClass]="{'list-view-pf-dnd': config.dragEnabled === true}"
-       *ngIf="itemsEmpty !== true">
+  <div class="list-group list-view-pf list-view-pf-view" dnd-list="items"
+       [ngClass]="{'list-view-pf-dnd': config.dragEnabled}"
+       *ngIf="!itemsEmpty">
     <div class='dndPlaceholder'></div>
     <div class="list-group-item {{item.rowClass}}"
          *ngFor="let item of items; let i = index"
          dnd-draggable="item"
          dnd-effect-allowed="move"
-         dnd-disable-if="config.dragEnabled !== true"
+         dnd-disable-if="!config.dragEnabled"
          dnd-dragstart="dragStart(item)"
          dnd-moved="dragMoved(item)"
          dnd-dragend="dragEnd(item)"
-         [ngClass]="{'drag-original': isDragOriginal(item) === true,
+         [ngClass]="{'drag-original': isDragOriginal(item),
                      'pf-selectable': selectItems,
-                     'active': isSelected(item) === true,
-                     'disabled': item.disabled === true,
-                     'list-view-pf-expand-active': item.expanded}">
+                     'active': isSelected(item),
+                     'disabled': item.disabled,
+                     'list-view-pf-expand-active': item.expanded,
+                     'list-group-item-heading-row': config.headingRow && i === 0}">
       <div class="list-group-item-header">
-        <div class="list-view-pf-dnd-drag-items" *ngIf="config.dragEnabled === true">
-          <div pf-transclude="parent" class="list-view-pf-main-info"></div>
+        <div class="list-view-pf-dnd-drag-items" *ngIf="config.dragEnabled">
+          <div class="list-view-pf-main-info"></div>
         </div>
-        <div [ngClass]="{'list-view-pf-dnd-original-items': config.dragEnabled === true}">
-          <div class="list-view-pf-expand" *ngIf="config.useExpandingRows === true">
-            <span class="fa fa-angle-right"
-                  *ngIf="item.rowExpansionDisabled !== true"
-                  (click)="toggleItemExpansion(item)"
-                  [ngClass]="{'fa-angle-down': item.expanded === true}"></span>
-            <span class="pf-expand-placeholder" *ngIf="item.rowExpansionDisabled === true"></span>
-          </div>
-          <div class="list-view-pf-checkbox" *ngIf="config.showSelectBox === true" >
-            <input type="checkbox" value="item.selected"
-                   [(ngModel)]="item.selected"
-                   [disabled]="item.disabled === true"
-                   (ngModelChange)="checkBoxChange(item)">
-          </div>
+        <div class="list-view-pf-dnd-drag-items-container"
+             [ngClass]="{'list-view-pf-dnd-original-items': config.dragEnabled}">
+          <div *ngIf="(config.headingRow && i === 0); then showExpRowHeader else showExpRow"></div>
+          <ng-template #showExpRowHeader>
+            <div class="pf-expand-placeholder" *ngIf="config.useExpandingRows"></div>
+          </ng-template>
+          <ng-template #showExpRow>
+            <div class="list-view-pf-expand" *ngIf="config.useExpandingRows">
+              <span class="fa fa-angle-right"
+                    *ngIf="!item.rowExpansionDisabled"
+                    (click)="toggleItemExpansion(item)"
+                    [ngClass]="{'fa-angle-down': item.expanded}"></span>
+              <span class="pf-expand-placeholder" *ngIf="item.rowExpansionDisabled"></span>
+            </div>
+          </ng-template>
+          <div *ngIf="(config.headingRow && i === 0); then showCbHeader else showCb"></div>
+          <ng-template #showCbHeader>
+            <div class="pf-cb-placeholder" *ngIf="config.showSelectBox"></div>
+          </ng-template>
+          <ng-template #showCb>
+            <div class="list-view-pf-checkbox" *ngIf="config.showSelectBox">
+              <input type="checkbox" value="item.selected"
+                     [(ngModel)]="item.selected"
+                     [disabled]="item.disabled"
+                     (ngModelChange)="checkBoxChange(item)">
+            </div>
+          </ng-template>
           <div class="list-view-pf-actions" *ngIf="actionTemplate !== undefined">
             <ng-template [ngTemplateOutlet]="actionTemplate" [ngOutletContext]="{ item: item, index: i }"></ng-template>
           </div>
@@ -45,15 +58,17 @@
           </div>
         </div>
         <div class="list-group-item-container container-fluid"
-             *ngIf="itemExpandedTemplate !== undefined && config.useExpandingRows === true && item.expanded">
+             *ngIf="!(config.headingRow && i === 0) && item.expanded
+               && itemExpandedTemplate !== undefined && config.useExpandingRows">
           <div class="close">
             <span class="pficon pficon-close" (click)="toggleItemExpansion(item)"></span>
           </div>
-          <ng-template [ngTemplateOutlet]="itemExpandedTemplate" [ngOutletContext]="{ item: item, index: i }"></ng-template>
+          <ng-template [ngTemplateOutlet]="itemExpandedTemplate"
+                       [ngOutletContext]="{ item: item, index: i }"></ng-template>
         </div>
       </div>
     </div>
   </div>
-  <alm-emptystate *ngIf="itemsEmpty === true" [config]="config.emptyStateConfig"
+  <alm-emptystate *ngIf="itemsEmpty" [config]="config.emptyStateConfig"
                   (onActionSelect)="handleAction($event)"></alm-emptystate>
 </span>

--- a/src/app/listview/listview.component.scss
+++ b/src/app/listview/listview.component.scss
@@ -10,25 +10,42 @@
   }
 }
 
-/* Margin for group heading */
-.list-view-pf-view {
-  //margin-top: 75px;
-}
-
 /* Group heading above list view */
 .list-group-heading {
   font-size: $font-size-base;
   font-weight: initial;
-  line-height: 1.3;
-  pointer-events: none;
-  position: absolute;
-  top: -40px;
   @media (max-width: 992px) { // @screen-md-min
     display: none;
   }
 }
 
+.list-view-pf .list-group-item {
+  margin-left: -2px;
+  margin-right: -2px;
+}
+
+.list-view-pf .list-group-item {
+  &.list-group-item-heading-row {
+    border-top: none;
+    pointer-events: none;
+    &:hover {
+      background-color: $color-pf-white;
+    }
+    i {
+      pointer-events: auto;
+    }
+  }
+}
+
+.list-view-pf-dnd-drag-items-container {
+  display: flex;
+}
+
 /* overriding pf base so that buttons have spaces between them */
 .pf-expand-placeholder {
   margin-right: 15px;
+}
+
+.pf-cb-placeholder {
+  margin-right: 40px;
 }


### PR DESCRIPTION
Refactored list view to place column headers on their own row. 

An issue was discovered after adding an info icon to the header. When the user hovers over the icon, a tooltip is displayed, but the first row is unexpectedly highlighted. Moving headers to their own row ensures mouseover/mouseenter events are not fired for the first list view row. 

This update will be used with the list view on the codebases page.

<img width="1438" alt="screen shot 2017-04-28 at 2 25 54 am" src="https://cloud.githubusercontent.com/assets/17481322/25516758/4236612a-2bba-11e7-95a2-e98c47fbecaf.png">
