### PR TITLE
Error in plugin 'gulp-ngc'

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "tslint": "5.0.0",
     "tslint-loader": "3.4.3",
     "typedoc": "0.5.9",
-    "typescript": "2.2.2",
+    "typescript": "2.3.4",
     "url-loader": "0.5.8",
     "webpack": "2.3.2",
     "webpack-bundle-analyzer": "2.3.1",


### PR DESCRIPTION
This PR fixes an issue with the build, which appears to be due to package dependencies. 

We started seeing this with the Travis build for patternfly-ng and the solution was to bump the typscript version. 

@sanbornsen reported this with the ngx-widgets repo, which no longer builds.