### PR TITLE
Set focus on an empty markdown component, when a user clicks on it

### DIFF
--- a/src/app/editable/almeditable.directive.ts
+++ b/src/app/editable/almeditable.directive.ts
@@ -51,6 +51,7 @@ export class AlmEditableDirective implements OnInit, OnChanges {
 
   makeEditable() {
     this.element.setAttribute('contenteditable', 'true');
+    this.element.focus();
   }
 
   makeNonEditable() {

--- a/src/app/markdown/markdown.component.html
+++ b/src/app/markdown/markdown.component.html
@@ -10,6 +10,7 @@
 </ul>
 <div class="editor-container">
   <div class="editor"
+    (click)="enableEditor()"
     [class.active]="editorActive"
     [class.show-less]="!showMore && !editorActive">
     <div class="editor-icon-container">

--- a/src/app/markdown/markdown.component.ts
+++ b/src/app/markdown/markdown.component.ts
@@ -101,6 +101,12 @@ export class MarkdownComponent implements OnChanges, OnInit {
     }
   }
 
+  enableEditor() {
+    if (this.rawText === '' ) {
+      this.activeEditor();
+    }
+  }
+
   activeEditor() {
     if (this.editAllow) {
       // Activate the editor


### PR DESCRIPTION
Following the GitHub pattern, if a markdown component is empty, clicking on it will make it editable and set focus on it. If the markdown component has text in it, the user needs to click on the edit icon to make it editable.