### PR TITLE
fix(githublinkarea): GitHub links now open in new tab. Fixes #970.

### DIFF
--- a/src/app/github-link-area/github-link-area.component.ts
+++ b/src/app/github-link-area/github-link-area.component.ts
@@ -84,7 +84,7 @@ export class GitHubLinkAreaComponent implements OnChanges {
         .join('<a class="gh-link" href="https://github.com/' +
           result[1] + '/' +
           result[2] + '/' +
-          'issues/' + result[3] + '" rel="nofollow">' +
+          'issues/' + result[3] + '" rel="nofollow" target="_blank">' +
           '<span class="fa fa-github gh-link-system"></span><span class="gh-link-label"> ' +
           result[2] + ':' + result[3] + ' ' +
           '<span ' +


### PR DESCRIPTION
Fixes part of #970. GitHub links now open in a new tab. 