### PR TITLE
fix(markdown): text and image overflow in markdown

### DIFF
--- a/src/app/markdown/markdown.component.less
+++ b/src/app/markdown/markdown.component.less
@@ -8,6 +8,9 @@
 .editor-container {
   width: 100%;
   background-color: @color-pf-black-200;
+  img {
+    max-width: 100%;
+  }
   .editor {
     word-wrap: break-word;
     .editor-markdown {

--- a/src/app/markdown/markdown.component.less
+++ b/src/app/markdown/markdown.component.less
@@ -15,9 +15,8 @@
         margin: 0;
     }
     .editor-preview {
-      h1, h2, h3, h4, h5, h6 {
+      h1 {
         margin-top: 0;
-        line-height: 1.1;
       }
     }
     .placeholder {

--- a/src/app/markdown/markdown.component.less
+++ b/src/app/markdown/markdown.component.less
@@ -9,13 +9,15 @@
   width: 100%;
   background-color: @color-pf-black-200;
   .editor {
+    word-wrap: break-word;
     .editor-markdown {
       font-size: 1.071em;
         margin: 0;
     }
     .editor-preview {
-      h1 {
+      h1, h2, h3, h4, h5, h6 {
         margin-top: 0;
+        line-height: 1.1;
       }
     }
     .placeholder {


### PR DESCRIPTION
Fix: https://github.com/openshiftio/openshift.io/issues/961

Before this PR:

![screenshot from 2017-09-27 15-56-34](https://user-images.githubusercontent.com/2561818/30909116-9d0e07c8-a39d-11e7-8095-3c0c6650987e.png)

Now in this PR:

![screenshot from 2017-09-27 15-58-41](https://user-images.githubusercontent.com/2561818/30909135-b2d044a4-a39d-11e7-8cf2-c0d9ad98e807.png)

