### PR TITLE
fix(panel): fix placement of panel with fixed navbar

### DIFF
--- a/src/app/slide-out-panel/slide-out-panel.component.less
+++ b/src/app/slide-out-panel/slide-out-panel.component.less
@@ -4,12 +4,11 @@
 .detail-panel {
   position: fixed;
   left: auto;
-  top: em(34);
+  top: 81px;
   right: 0;
   bottom: 0;
   width: 50%;
-  min-width: em(250);
-  padding: em(20) 0 em(20) em(10);
+  min-width: 250px;
   border-left: 1px solid;
   border-left-color: darken(@color-pf-white, 20%);
   background-color: @color-pf-white;


### PR DESCRIPTION
Update the placement of the slideout panel to account for the fixed navbar. Also adjusts errors in the Less conversion from `em` to `px` when calculated in the browser (this caused placement issues).

fixes https://github.com/openshiftio/openshift.io/issues/1180