### PR TITLE
fix(markdown): fix css for markdown as per VD

### DIFF
--- a/src/app/markdown/markdown.component.less
+++ b/src/app/markdown/markdown.component.less
@@ -45,11 +45,6 @@
         opacity: 0;
         padding: 7px;
         margin-left: 10px;
-        background-color: @color-pf-black-200;
-        border: 1px solid;
-        border-color: @color-pf-black-300;
-        border-radius: 50%;
-        box-shadow: 0 1px 3px @color-pf-black-300;
         transition: all ease-out .3s;
       }
     }

--- a/src/app/markdown/markdown.component.less
+++ b/src/app/markdown/markdown.component.less
@@ -7,13 +7,11 @@
 }
 .editor-container {
   width: 100%;
-  background-color: @color-pf-black-200;
   img {
     max-width: 100%;
   }
   .editor {
     background-color: @color-pf-white;
-    padding-right: 30px;
     background-clip: content-box;
     border: 1px solid @color-pf-black-400;
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
@@ -41,17 +39,25 @@
       position: relative;
       .edit-icon {
         position: absolute;
-        left: 100%;
+        right: 5px;
         top: 5px;
         cursor: pointer;
         opacity: 0;
+        padding: 7px;
         margin-left: 10px;
+        background-color: @color-pf-black-200;
+        border: 1px solid;
+        border-color: @color-pf-black-300;
+        border-radius: 50%;
+        box-shadow: 0 1px 3px @color-pf-black-300;
+        transition: all ease-out .3s;
       }
     }
     &:hover {
       border: 1px solid @color-pf-blue-200;
       .edit-icon {
         opacity: 1;
+        transition: all ease-in .3s;
       }
     }
   }


### PR DESCRIPTION
fix CSS for markdown edit icon as per VD: https://redhat.invisionapp.com/share/5AFTMT37QDE#/screens/279008732_MarkDown_02


<img width="354" alt="screen shot 2018-02-20 at 1 25 07 pm" src="https://user-images.githubusercontent.com/10396359/36412767-92792344-1641-11e8-941b-105209af87e6.png">
