### PR TITLE
fix(icon): default icon bug fixed

### DIFF
--- a/src/app/icon/almicon-test.component.ts
+++ b/src/app/icon/almicon-test.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'alm-icon-test',
+  template: ''
+})
+
+export class AlmIconTest {}

--- a/src/app/icon/almicon.directive.spec.ts
+++ b/src/app/icon/almicon.directive.spec.ts
@@ -1,0 +1,60 @@
+import { By } from '@angular/platform-browser';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AlmIconTest } from './almicon-test.component';
+import { AlmIconDirective } from './almicon.directive';
+
+describe('AlmIcon directive - ', () => {
+  let comp: AlmIconTest;
+  let fixture: ComponentFixture<AlmIconTest>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        AlmIconTest,
+        AlmIconDirective
+      ]
+    });
+  });
+
+  it('Canary test should pass', () => {
+    expect(true).toBeTruthy();
+  });
+
+  it('Should apply appropriate class and color', () => {
+    TestBed.overrideComponent(AlmIconTest, {
+      set: {
+        template: '<span almIcon iconType="new"></span>'
+      }
+    })
+    .compileComponents()
+    .then(() => {
+      fixture = TestBed.createComponent(AlmIconTest);
+      comp = fixture.componentInstance;
+      fixture.detectChanges();
+      let compiled = fixture.debugElement.nativeElement
+        .querySelector('span');
+      expect(compiled.className).toBe('fa fa-star');
+      expect(compiled.style.color).toBe('rgb(88, 47, 192)');
+    });
+  });
+
+  it('Should apply default class and color', () => {
+    TestBed.overrideComponent(AlmIconTest, {
+      set: {
+        template: '<span almIcon iconType="anything"></span>'
+      }
+    })
+    .compileComponents()
+    .then(() => {
+      fixture = TestBed.createComponent(AlmIconTest);
+      comp = fixture.componentInstance;
+      fixture.detectChanges();
+      let compiled = fixture.debugElement.nativeElement
+        .querySelector('span');
+      expect(compiled.className).toBe('fa fa-crosshairs');
+      expect(compiled.style.color).toBe('rgb(0, 0, 0)');
+    });
+  });
+
+});
+

--- a/src/app/icon/almicon.directive.ts
+++ b/src/app/icon/almicon.directive.ts
@@ -8,7 +8,7 @@ import { IconMap } from './iconmap';
 
 export class AlmIconDirective implements OnInit, OnChanges {
   @Input() iconType: string = 'none';
-  
+
   constructor(private elementRef: ElementRef) {
   }
 
@@ -35,7 +35,7 @@ export class AlmIconDirective implements OnInit, OnChanges {
 
     existingClassNames.forEach((item: any) => {
       if (allClassesInMap.indexOf(item) > -1) {
-        element.classList.remove(item);             
+        element.classList.remove(item);
       }
     });
 
@@ -44,9 +44,9 @@ export class AlmIconDirective implements OnInit, OnChanges {
       element.setAttribute("style", "color:" + iconColor);
       IconMap[this.iconType].icon.forEach((item: any) => {
         element.classList.add(item);
-      });       
+      });
     } else {
-      iconColor = IconMap[this.iconType].color;
+      iconColor = IconMap['default'].color;
       element.setAttribute("style", "color:" + iconColor);
       IconMap['default'].icon.forEach((item: any) => {
         element.classList.add(item);


### PR DESCRIPTION
When any icon type does not exist in our icon map it should go for the default icon type to show the default icon and color. 
It was codded correct, but in the ```else``` part where it actually should take the default color, it was trying to fetch color from ```IconMap[this.iconType].color``` where ```IconMap[this.iconType]``` is undefined.