### PR TITLE
fix(markdown): improve markdown table styling

### DIFF
--- a/src/app/markdown/markdown.component.less
+++ b/src/app/markdown/markdown.component.less
@@ -25,6 +25,16 @@
       h1 {
         margin-top: 0;
       }
+      table {
+        border-collapse: collapse;
+      }
+      table, td, th {
+        border: 1px solid @color-pf-black-300;
+        padding: 0.4em;
+      }
+      tr:nth-child(even) {
+        background-color: @color-pf-black-150;
+      }
     }
     .placeholder {
       font-size: 1em;


### PR DESCRIPTION
Rendered tables currently show up in OpenShift.io without borders and without any padding whatsoever. That makes them really hard to identify as tables.

This change adds 

1. a border, 
2. padding and 
3. alternating row colors (taken from the [color palette](https://www.patternfly.org/styles/color-palette/))  

to a rendered table.

## Before

This is how the rendering of a table looks in OpenShift.io before the style changes:

![bildschirmfoto von 2018-04-13 09-50-22](https://user-images.githubusercontent.com/193408/38723037-27830234-3f00-11e8-8154-f5e02f304033.png)

## After

And this is how it looks with the style changes (applied in Chrome):

![bildschirmfoto von 2018-04-13 09-47-37](https://user-images.githubusercontent.com/193408/38722962-f3ab6794-3eff-11e8-850c-dcd1646dc613.png)

## Try standalone

Here's a preview of the changes standalone:

https://www.w3schools.com/code/tryit.asp?filename=FQB3L3C4L6CM