### PR TITLE
fix(dependencies): use peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ fabric8-ui, you should:
 1. Run `npm run watch:library` in this directory. This will build ngx-widgets as
 a library and then set up a watch task to rebuild any ts, html and less files you
 change.
-2. In the webapp into which you are embedding, run `npm link <path to ngx-widgets>/dist-watch`.
-This will create a symlink from `node_modules/fabric8-planner` to the `dist-watch` directory
+2. In the webapp into which you are embedding, run `npm link <path to ngx-widgets>/dist-watch --production`.
+This will create a symlink from `node_modules/ngx-widgets` to the `dist-watch` directory
 and install that symlinked node module into your webapp.
 3. Run your webapp in development mode, making sure you have a watch on `node_modules/ngx-widgets`
 enabled. To do this using a typical Angular Webpack setup, such as the one based on Angular Class,

--- a/package.json
+++ b/package.json
@@ -70,22 +70,28 @@
     "npm": "5.3.0"
   },
   "dependencies": {
-    "@angular/animations": "^4.4.4",
-    "@angular/common": "^4.4.4",
-    "@angular/core": "^4.4.4",
-    "@angular/forms": "^4.4.4",
-    "@angular/router": "^4.4.4",
     "moment": "^2.18.1",
-    "patternfly-ng": "^0.13.1"
+    "patternfly-ng": "^3.1.5"
   },
-  "peerDependencies": {},
+  "peerDependencies": {
+    "@angular/animations": "^4.4.6",
+    "@angular/common": "^4.4.6",
+    "@angular/core": "^4.4.6",
+    "@angular/forms": "^4.4.6",
+    "@angular/router": "^4.4.6"
+  },
   "devDependencies": {
-    "@angular/compiler": "^4.4.4",
-    "@angular/compiler-cli": "^4.4.4",
-    "@angular/http": "^4.4.4",
-    "@angular/platform-browser": "^4.4.4",
-    "@angular/platform-browser-dynamic": "^4.4.4",
-    "@angular/platform-server": "^4.4.4",
+    "@angular/animations": "^4.4.6",
+    "@angular/common": "^4.4.6",
+    "@angular/compiler": "^4.4.6",
+    "@angular/compiler-cli": "^4.4.6",
+    "@angular/core": "^4.4.6",
+    "@angular/forms": "^4.4.6",
+    "@angular/http": "^4.4.6",
+    "@angular/platform-browser": "^4.4.6",
+    "@angular/platform-browser-dynamic": "^4.4.6",
+    "@angular/platform-server": "^4.4.6",
+    "@angular/router": "^4.4.6",
     "@krux/condition-jenkins": "1.0.1",
     "@types/core-js": "0.9.43",
     "@types/jasmine": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,8 @@
     "webpack-dev-server": "2.9.3",
     "webpack-dll-bundles-plugin": "1.0.0-beta.5",
     "webpack-md5-hash": "0.0.5",
-    "webpack-merge": "4.1.0"
+    "webpack-merge": "4.1.0",
+    "zone.js": "0.8.18"
   },
   "release": {
     "branch": "master",


### PR DESCRIPTION
related to openshiftio/openshift.io#3686

Move angular from `dependencies` to `peerDependencies`.

`npm link --production` must be used to omit installation of `devDependencies` when linking.

Also updated patternfly-ng to align with fabric8-ui because version 0.13.1 did not use `peerDependencies` for angular.