### PR TITLE
fix(build): fix gulp script for watch and missing css in dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,8 @@
   "name": "ngx-widgets",
   "version": "0.0.0-development",
   "description": "A collection of Angular components and other useful things to be shared.",
-  "main": "bundles/ngx-widgets.umd.js",
-  "module": "index.js",
-  "typings": "index.d.ts",
+  "module": "src/app/index.js",
+  "typings": "src/app/index.d.ts",
   "scripts": {
     "build": "npm-run-all --serial lint:less lint:ts build:aot build:bundle",
     "build:aot": "npm run rimraf -- build build-aot && gulp build-aot",

--- a/tsconfig-aot.json
+++ b/tsconfig-aot.json
@@ -30,7 +30,7 @@
       "@angular/router": ["node_modules/@angular/router"],
       "rxjs/*": ["node_modules/rxjs/*"]
     },
-    "rootDir": "build/src/app",
+    "rootDir": "build",
     "skipLibCheck": true,
     "sourceMap": true,
     "strictNullChecks": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,7 @@
       "@angular/router": ["node_modules/@angular/router"],
       "rxjs/*": ["node_modules/rxjs/*"]
     },
-    "rootDir": "build/src/app",
+    "rootDir": "build",
     "skipLibCheck": true,
     "sourceMap": true,
     "strictNullChecks": false,


### PR DESCRIPTION
Fixed the `ngx-widgets` gulp scripts to add the missing CSS files to the `dist` dir.

Also fixed the `watch` commands to ensure all CSS files and inline HTML templates are updated.