### PR TITLE
fix(package.json): add entry point `main` for node packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ngx-widgets",
   "version": "0.0.0-development",
   "description": "A collection of Angular components and other useful things to be shared.",
+  "main": "src/app/index.js",
   "module": "src/app/index.js",
   "typings": "src/app/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### Issue:
With ngx-widgets version 3.1.2(https://github.com/fabric8-ui/ngx-widgets/pull/156) the directory structure changed for published package which caused the following error in planner
```
{ Error: /home/sbudhwar/node_modules/ngx-widgets/index.js: Couldn't find preset "env" relative to directory "/home/sbudhwar/node_modules/ngx-widgets"
Transform function: 

function (context, callback) {
        if (!context.js) {
            return callback(undefined, false);
        }
        if (isEs6(context.js.ast)) {
            options.filename = context.filename;
            log.debug("Transforming %s", options.filename);
            try {
                context.source = babel.transform(context.source, options).code;
                context.js.ast = acorn.parse(context.source, { sourceType: "module" });
                return callback(undefined, true);
            }
            catch (error) {
                return callback(error, false);
            }
        }
        else {
            return callback(undefined, false);
        }
    }

    at Transformer.handleError (/home/sbudhwar/fabric8/fabric8-planner/node_modules/karma-typescript/src/bundler/transformer.ts:103:19)
    at /home/sbudhwar/fabric8/fabric8-planner/node_modules/karma-typescript/src/bundler/transformer.ts:87:26
    at transform (/home/sbudhwar/fabric8/fabric8-planner/node_modules/karma-typescript-es6-transform/src/transform.ts:69:24)
    at /home/sbudhwar/fabric8/fabric8-planner/node_modules/karma-typescript/src/bundler/transformer.ts:86:17
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickDomainCallback (internal/process/next_tick.js:218:9)
  domain: 
   Domain {
     domain: null,
     _events: {},
     _eventsCount: 0,
     _maxListeners: undefined,
     members: [] }
```
### Cause:
`main` property was missing from the `package.json` which caused the node to look for an entry point in the root directory and because of the change in directory structure the entry point for the package resides in `src/app/index.js`

### Solution:
Add `main` property in package.json with correct entry point