### PR TITLE
fix(markdown): handle click event on preview

### DIFF
--- a/src/app/markdown/markdown.component.html
+++ b/src/app/markdown/markdown.component.html
@@ -10,7 +10,7 @@
 </ul>
 <div class="editor-container">
   <div class="editor" #previewArea
-    (click)="enableEditor()"
+    (click)="enableEditor($event);"
     [class.active]="editorActive"
     [class.show-less]="!showMore && !editorActive">
     <div class="editor-icon-container">

--- a/src/app/markdown/markdown.component.ts
+++ b/src/app/markdown/markdown.component.ts
@@ -232,7 +232,10 @@ export class MarkdownComponent implements OnChanges, OnInit, AfterViewChecked {
     }
   }
 
-  enableEditor() {
+  enableEditor(event: MouseEvent) {
+    if (event) {
+      event.stopPropagation();
+    }
     if (this.rawText === '') {
       this.activeEditor();
     }


### PR DESCRIPTION
This PR is an enhancement over https://github.com/fabric8-ui/ngx-widgets/pull/157

Due to event bubbling the click on the preview-area was getting caught as a click outside the markdown and hence the markdown was not opening in editing mode while clicking on the preview-area.